### PR TITLE
Inline plugin-check-action to fix wp-env URL-plugin bug on new runner image

### DIFF
--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -65,12 +65,82 @@ jobs:
               id: slug
               run: echo "slug=$(jq -r .name package.json)" >> $GITHUB_OUTPUT
 
-            - name: Run plugin check
-              uses: wordpress/plugin-check-action@18573eb38f13543484a1f095672dae3849a4fbb0 # v1.1.6
+            # The following steps inline wordpress/plugin-check-action to work
+            # around a bug in @wordpress/env on the ubuntu-24.04 runner image
+            # >=20260525.161 (Node.js 24.16.0): including a URL-based plugin in
+            # .wp-env.json causes wp-env start to silently exit 0 without
+            # booting Docker, so the plugin check never runs. See:
+            # https://github.com/WordPress/plugin-check-action/issues/579
+            # https://github.com/WordPress/gutenberg/issues/78762
+            # Revert to `uses: wordpress/plugin-check-action@...` once resolved.
+
+            - name: Setup wp-env
+              env:
+                  PLUGIN_SLUG: ${{ steps.slug.outputs.slug }}
+              run: |
+                  PLUGIN_DIR=$(realpath './build')
+                  echo "PLUGIN_DIR=$PLUGIN_DIR" >> "$GITHUB_ENV"
+                  echo "PLUGIN_SLUG=$PLUGIN_SLUG" >> "$GITHUB_ENV"
+
+                  # plugin-check is intentionally NOT listed as a URL plugin —
+                  # that download path triggers the Node 24.16.0 / wp-env bug.
+                  # It is installed via wp-cli after the environment starts.
+                  cat > .wp-env.json << EOF
+                  {
+                    "core": null,
+                    "port": 8880,
+                    "testsEnvironment": false,
+                    "mappings": { "wp-content/plugins/${PLUGIN_SLUG}": "${PLUGIN_DIR}" }
+                  }
+                  EOF
+
+                  # Pin to a known-good version so a future wp-env regression
+                  # can't silently break CI the same way again.
+                  npm -g --no-fund i @wordpress/env@11.7.0
+
+            - name: Start wp-env
+              uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
               with:
-                  wp-version: 'latest'
-                  build-dir: './build/'
-                  slug: ${{ steps.slug.outputs.slug }}
+                  timeout_minutes: 10
+                  max_attempts: 3
+                  shell: bash
+                  command: wp-env start
+
+            - name: Run plugin check
+              run: |
+                  echo "::group::Debugging information"
+                  wp-env run cli wp cli info
+                  wp-env run cli wp plugin list
+                  echo "::endgroup::"
+
+                  echo "::group::Install plugin-check"
+                  wp-env run cli wp plugin install plugin-check --activate
+                  echo "::endgroup::"
+
+                  wp-env run cli wp plugin activate "$PLUGIN_SLUG"
+
+                  echo "::group::Run Plugin Check"
+                  RESULTS="${RUNNER_TEMP}/plugin-check-results.json"
                   # Note: Remove 'plugin_updater_detected' if this plugin is intended for the dotorg directory.
                   # Note: Add 'readme_reserved_contributors' if the plugin has wordpressdotorg as a contributor.
-                  ignore-codes: 'plugin_updater_detected'
+                  wp-env run cli wp plugin check "$PLUGIN_SLUG" \
+                    --format=json \
+                    --ignore-codes=plugin_updater_detected \
+                    --slug="$PLUGIN_SLUG" \
+                    --require=./wp-content/plugins/plugin-check/cli.php \
+                    > "$RESULTS"
+                  cat "$RESULTS"
+                  echo "::endgroup::"
+
+                  if [ -s "$RESULTS" ] && [ "$(jq 'length' "$RESULTS")" -gt 0 ]; then
+                    echo "::error::Plugin Check reported issues for $PLUGIN_SLUG"
+                    exit 1
+                  fi
+
+            - name: Upload plugin-check results
+              if: always()
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+              with:
+                  name: plugin-check-results-${{ steps.slug.outputs.slug }}
+                  path: ${{ runner.temp }}/plugin-check-results.json
+                  if-no-files-found: ignore


### PR DESCRIPTION
## Problem

`Run Plugin Check` fails on **`main` and every open PR** (including #103) with:

```
✖ Environment not initialized. Run `wp-env start` first.
```

`wordpress/plugin-check-action` writes a `.wp-env.json` containing a **URL-based plugin** (`https://downloads.wordpress.org/plugin/plugin-check.zip`). On the `ubuntu-24.04` runner image `>=20260525.161` (Node.js 24.16.0), `wp-env start` silently exits `0` without booting Docker when a URL plugin is present, so the plugin check never runs and the job fails.

This is unrelated to any individual PR's changes — it's a runner-image/wp-env regression. (The separate `cs2pr` download failure seen on some PRs is transient GitHub-API flakiness and clears on re-run.)

Upstream tracking: https://github.com/WordPress/plugin-check-action/issues/579

## Fix

Inline the `plugin-check-action` steps in `.github/workflows/plugin-check.yml`:

- Build a `.wp-env.json` with **no URL plugin** (`testsEnvironment: false`).
- Pin `@wordpress/env@11.7.0` so a future wp-env regression can't silently break CI the same way again.
- Start wp-env via the `nick-fields/retry` action.
- Install `plugin-check` via wp-cli **after** the environment boots, then run `wp plugin check`, failing the job if it reports any issues.

Slug continues to come from `package.json` `.name`, and the `plugin_updater_detected` ignore-code (plus its Notes) is preserved. Revert to `uses: wordpress/plugin-check-action@...` once the upstream bug is resolved.

Mirrors the workaround from `WordPress/performance@56c61e6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
